### PR TITLE
Relax Atlassian API dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
             pyPkgs."uv-build"
           ];
           pythonRelaxDeps = [
+            "atlassian-python-api"
             "environs"
             "python-multipart"
             "uvicorn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name = "Philipp Schmitt", email = "philipp@schmitt.co" }
 ]
 dependencies = [
-  "atlassian-python-api>=5,<5.1",
+  "atlassian-python-api>=4,<5",
   "beautifulsoup4>=4.12.2,<5.0.0",
   "diskcache>=5.6.1,<6.0.0",
   "environs>=14,<16",

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "atlassian-python-api"
-version = "5.0.1"
+version = "4.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -61,9 +61,9 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/a2/0cde93bdbc10e194ea01aaedaf63a6a1d036bbf560f9fad2ff41248adfb1/atlassian_python_api-5.0.1.tar.gz", hash = "sha256:d4c724647c3797340bd1aae19bf03bf7e2f0218efcc825fcffe3e564838ac64b", size = 1021584, upload-time = "2026-08-15T16:33:27.389Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/e8/f23b7273e410c6fe9f98f9db25268c6736572f22a9566d1dc9ed3614bb68/atlassian_python_api-4.0.7.tar.gz", hash = "sha256:8d9cc6068b1d2a48eb434e22e57f6bbd918a47fac9e46b95b7a3cefb00fceacb", size = 271149, upload-time = "2025-08-21T13:19:40.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/3a/bb2b310dba5c9bf4fe876e322bbf07bb9f960cab4247231571a3dd47f407/atlassian_python_api-5.0.1-py3-none-any.whl", hash = "sha256:650b20ee660e80e31f3f76e7fcbc3c45d66da6cd7266a217d680a5af1666abb1", size = 257580, upload-time = "2026-08-15T16:33:24.808Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/83/e4f9976ce3c933a079b8931325e7a9c0a8bba7030a2cb85764c0048f3479/atlassian_python_api-4.0.7-py3-none-any.whl", hash = "sha256:46a70cb29eaab87c0a1697fccd3e25df1aa477e6aa4fb9ba936a9d46b425933c", size = 197746, upload-time = "2025-08-21T13:19:39.044Z" },
 ]
 
 [[package]]
@@ -510,7 +510,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -867,7 +867,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "atlassian-python-api", specifier = ">=5,<5.1" },
+    { name = "atlassian-python-api", specifier = ">=4,<5" },
     { name = "beautifulsoup4", specifier = ">=4.12.2,<5.0.0" },
     { name = "diskcache", specifier = ">=5.6.1,<6.0.0" },
     { name = "environs", specifier = ">=14,<16" },


### PR DESCRIPTION
## Summary

- Relax `atlassian-python-api` to the Nixpkgs-supported 4.x series.
- Keep the Nix package compatible with the relaxed Python metadata.
- Regenerate `uv.lock` for 4.0.7.

## Root cause

Nixpkgs currently provides `atlassian-python-api` 4.0.7, while the application metadata required 5.x. The Nix runtime dependency check therefore rejected the package during the Home Manager build.

## Validation

- `nixfmt`
- `statix check`
- `uv lock --check`
- `nix build .#jcalapi --no-link`